### PR TITLE
fix: Use Correct Link to Repo

### DIFF
--- a/.replrc.js
+++ b/.replrc.js
@@ -62,7 +62,7 @@ const code_sample = theme.code(
 );
 
 const docs = theme.normal(
-  `You can see the list of APIs at ${theme.link("https://github.com/whitehead-ai/sdk#readme")}`
+  `You can see the list of APIs at ${theme.link("https://github.com/whitehead-ai/node-sdk#readme")}`
 );
 
 const varsInfo = chalk.dim("Globals: " + theme.code(Object.keys(context).join(", ")));

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Features
 
-- Docs can be found [here](https://whitehead-ai.github.io/sdk).
+- Docs can be found [here](https://whitehead-ai.github.io/node-sdk).
 - Typesafe queries. Written in typescript.
 - Bindings are included in the package.
 - Bindings for _reasonml/bucklescript/rescript_ and _flow.js_ coming soon.
@@ -33,7 +33,7 @@ whitehead-playground
 
 #### Playground screenshot
 
-![Playground screenshot](https://github.com/whitehead-ai/sdk/raw/main/assets/whitehead_playground_screenshot.png?raw=true "Playground screenshot")
+![Playground screenshot](https://github.com/whitehead-ai/node-sdk/raw/main/assets/whitehead_playground_screenshot.png?raw=true "Playground screenshot")
 
 ### Usage as an SDK
 

--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/whitehead-ai/sdk.git"
+        "url": "git+https://github.com/whitehead-ai/node-sdk.git"
     },
     "author": "diwank@whitehead.ai",
     "license": "ISC",
     "bugs": {
-        "url": "https://github.com/whitehead-ai/sdk/issues"
+        "url": "https://github.com/whitehead-ai/node-sdk/issues"
     },
-    "homepage": "https://github.com/whitehead-ai/sdk#readme",
+    "homepage": "https://github.com/whitehead-ai/node-sdk#readme",
     "devDependencies": {
         "@graphql-codegen/cli": "1.21.1",
         "@graphql-codegen/time": "^2.0.2",


### PR DESCRIPTION
My guess is that the repo was renamed at some point